### PR TITLE
Add api format v2

### DIFF
--- a/src/main/java/melky/resourcepacks/ResourcePacksConfig.java
+++ b/src/main/java/melky/resourcepacks/ResourcePacksConfig.java
@@ -22,6 +22,25 @@ public interface ResourcePacksConfig extends Config
 		HUB
 	}
 
+	enum ApiFormat
+	{
+		v1,
+		v2;
+
+		public static ApiFormat getFormat(String input)
+		{
+			for (ApiFormat format : ApiFormat.values())
+			{
+				if (format.toString().equals(input))
+				{
+					return format;
+				}
+			}
+
+			return v1;
+		}
+	}
+
 	@ConfigSection(name = "Resource pack paths",
 		description = "Contains resource pack paths",
 		position = 2
@@ -159,4 +178,23 @@ public interface ResourcePacksConfig extends Config
 	{
 		return "";
 	}
+
+	@ConfigItem(
+		keyName = "apiFormat",
+		hidden = true,
+		description = "",
+		name = ""
+	)
+	default ApiFormat apiFormat()
+	{
+		return ApiFormat.v1;
+	}
+
+	@ConfigItem(
+		keyName = "apiFormat",
+		hidden = true,
+		description = "",
+		name = ""
+	)
+	void apiFormat(ApiFormat apiFormat);
 }

--- a/src/main/java/melky/resourcepacks/ResourcePacksManager.java
+++ b/src/main/java/melky/resourcepacks/ResourcePacksManager.java
@@ -64,27 +64,6 @@ import okhttp3.Response;
 @Slf4j
 public class ResourcePacksManager
 {
-	enum ApiFormat
-	{
-		v1,
-		v2;
-
-		public static ApiFormat getFormat(String input)
-		{
-			for (ApiFormat format : ApiFormat.values())
-			{
-				if (format.toString().equals(input))
-				{
-					return format;
-				}
-			}
-
-			return v1;
-		}
-	}
-
-	private ApiFormat currentFormat;
-
 	@Getter
 	private final Properties properties = new Properties();
 
@@ -364,7 +343,7 @@ public class ResourcePacksManager
 		overrideSprites();
 		applyWidgetOverrides();
 
-		if (currentFormat == ApiFormat.v1)
+		if (config.apiFormat() == ResourcePacksConfig.ApiFormat.v1)
 		{
 			adjustWidgetDimensions(false);
 			adjustWidgetDimensions(true);
@@ -538,7 +517,7 @@ public class ResourcePacksManager
 			for (SpriteOverride spriteOverride : collection)
 			{
 				SpritePixels spritePixels = getSpritePixels(spriteOverride, currentPackPath);
-				if (currentFormat != ApiFormat.v1)
+				if (config.apiFormat() != ResourcePacksConfig.ApiFormat.v1)
 				{
 					SpritePixels[] sp = client.getSprites(client.getIndexSprites(), spriteOverride.getSpriteID(), 0);
 					if (sp == null)
@@ -616,13 +595,13 @@ public class ResourcePacksManager
 		}
 		catch (IOException e)
 		{
-			currentFormat = ApiFormat.v1;
+			config.apiFormat(ResourcePacksConfig.ApiFormat.v1);
 			log.debug("properties not found");
 			resetOverlayColor();
 			return;
 		}
 
-		currentFormat = ApiFormat.getFormat((String) properties.getOrDefault("api_format", "v1"));
+		config.apiFormat(ResourcePacksConfig.ApiFormat.getFormat((String) properties.getOrDefault("api_format", "v1")));
 		if (config.allowOverlayColor())
 		{
 			changeOverlayColor();

--- a/src/main/java/melky/resourcepacks/ResourcePacksPlugin.java
+++ b/src/main/java/melky/resourcepacks/ResourcePacksPlugin.java
@@ -198,7 +198,7 @@ public class ResourcePacksPlugin extends Plugin
 	@Subscribe
 	public void onScriptPostFired(ScriptPostFired event)
 	{
-		if (WidgetOverride.scriptWidgetOverrides.containsKey(event.getScriptId()) && !resourcePacksManager.getColorProperties().isEmpty())
+		if (WidgetOverride.scriptWidgetOverrides.containsKey(event.getScriptId()) && !resourcePacksManager.getProperties().isEmpty())
 		{
 			for (WidgetOverride widgetOverride : WidgetOverride.scriptWidgetOverrides.get(event.getScriptId()))
 			{

--- a/src/main/java/melky/resourcepacks/SpriteOverride.java
+++ b/src/main/java/melky/resourcepacks/SpriteOverride.java
@@ -1124,7 +1124,9 @@ enum SpriteOverride
 	IMPLING_LUCKY(SpriteID.PURO_PURO_LUCKY_IMPLING, Folder.IMPLING),
 	;
 
+	@Getter
 	private final int spriteID;
+	@Getter
 	private final Folder folder;
 	@Getter
 	private static final ImmutableSetMultimap<Folder, SpriteOverride> overrides;

--- a/src/test/java/melky/resourcepacks/ResourcePacksPluginTest.java
+++ b/src/test/java/melky/resourcepacks/ResourcePacksPluginTest.java
@@ -1,7 +1,12 @@
 package melky.resourcepacks;
 
+import com.google.common.base.Strings;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
+import org.junit.Test;
 
 public class ResourcePacksPluginTest
 {
@@ -9,5 +14,36 @@ public class ResourcePacksPluginTest
 	{
 		ExternalPluginManager.loadBuiltin(ResourcePacksPlugin.class);
 		RuneLite.main(args);
+	}
+
+	@Test
+	public void moveImages() throws IOException
+	{
+		String inputFolder = System.getProperty("resources.inputFolder");
+		String outputFolder = System.getProperty("resources.outputFolder");
+		if (Strings.isNullOrEmpty(inputFolder) || Strings.isNullOrEmpty(outputFolder)) {
+			throw new RuntimeException("inputFolder and outputFolder need to be defined");
+		}
+
+
+		for (SpriteOverride override: SpriteOverride.values()) {
+			File folder = createOrRetrieve(outputFolder + "/" + override.getFolder().toString().toLowerCase());
+			File destinationSprite = new File(folder, override.toString().toLowerCase().replaceFirst(override.getFolder().toString().toLowerCase() + "_", "") + ".png");
+			File sourceSprite = new File(inputFolder + "/" + override.getSpriteID() + "-0.png");
+
+			if (sourceSprite.exists()) {
+				Files.copy(sourceSprite, destinationSprite);
+			}
+		}
+	}
+
+	private File createOrRetrieve(final String target) throws IOException
+	{
+		File outputDir = new File(target);
+		if (!outputDir.exists()) {
+			outputDir.mkdirs();
+		}
+
+		return outputDir;
 	}
 }


### PR DESCRIPTION
Closes https://github.com/melkypie/resource-packs/issues/60

This leverages the sprite pixel changes in RuneLite master so images can be changed directly from the cache dumps. It also allows other plugins to use the overridden sprites easier if they want to do external drawing. 

The v2 zip would need to be added to the README and existing packs would need to be updated to support the new version.

[sample-vanilla-v2.zip](https://github.com/melkypie/resource-packs/files/5638557/sample-vanilla-v2.zip)