### PR TITLE
Fix FlatLaf Compatability

### DIFF
--- a/src/main/java/melky/resourcepacks/ResourcePacksPlugin.java
+++ b/src/main/java/melky/resourcepacks/ResourcePacksPlugin.java
@@ -267,7 +267,6 @@ public class ResourcePacksPlugin extends Plugin
 		if (config.hideSidePanelButton())
 		{
 			clientToolbar.removeNavigation(navButton);
-			navButton.setSelected(false);
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #222 

This PR is a quick patch for the plugin to be compatible with the RuneLite FlatLaf changes (runelite/runelite#17284), that was made live recently, that broke the plugin.

The only change is removing `navButton.setSelected(false)`, as it doesn't exist anymore, and `.removeNavigation()` handles that automatically now. The plugin still behaves as expected.